### PR TITLE
fix:插件闪屏广告，lateinit对象空指针问题修复

### DIFF
--- a/android/src/main/cn/io/github/nullptrx/pangleflutter/view/FlutterSplashView.kt
+++ b/android/src/main/cn/io/github/nullptrx/pangleflutter/view/FlutterSplashView.kt
@@ -31,16 +31,22 @@ class FlutterSplashView(
   private val container: FrameLayout
   private var mTTSplashAd: TTSplashAd? = null
   private var hideSkipButton = false
-  private lateinit var countDownTimer: CountDownTimer
+  private var countDownTimer: CountDownTimer? = null
 
   override fun onFlutterViewDetached() {
     destroy()
   }
 
   private fun destroy() {
-    countDownTimer.cancel()
-    TTMediationAdSdk.unregisterConfigCallback(mSettingConfigCallback)
-    container.removeAllViews()
+    if(countDownTimer != null){
+      countDownTimer!!.cancel()
+    }
+    if(mSettingConfigCallback != null){
+      TTMediationAdSdk.unregisterConfigCallback(mSettingConfigCallback)
+    }
+    if(container != null){
+      container.removeAllViews()
+    }
     if (mTTSplashAd != null) {
       mTTSplashAd!!.destroy()
     }
@@ -129,7 +135,7 @@ class FlutterSplashView(
         override fun onTick(millisUntilFinished: Long) {
         }
       }
-      countDownTimer.start()
+      countDownTimer!!.start()
     }
   }
 
@@ -170,7 +176,9 @@ class FlutterSplashView(
     method: String,
     arguments: Map<String, Any?> = mapOf()
   ) {
-    countDownTimer.cancel()
+    if(countDownTimer != null){
+      countDownTimer!!.cancel()
+    }
     methodChannel.invokeMethod(method, arguments)
   }
 }

--- a/android/src/main/cn/io/github/nullptrx/pangleflutter/view/FlutterSplashView.kt
+++ b/android/src/main/cn/io/github/nullptrx/pangleflutter/view/FlutterSplashView.kt
@@ -33,30 +33,22 @@ class FlutterSplashView(
   private var hideSkipButton = false
   private var countDownTimer: CountDownTimer? = null
 
-  override fun onFlutterViewDetached() {
-    destroy()
-  }
-
-  private fun destroy() {
-    if(countDownTimer != null){
-      countDownTimer!!.cancel()
-    }
-    if(mSettingConfigCallback != null){
-      TTMediationAdSdk.unregisterConfigCallback(mSettingConfigCallback)
-    }
-    if(container != null){
-      container.removeAllViews()
-    }
-    if (mTTSplashAd != null) {
-      mTTSplashAd!!.destroy()
-    }
-    methodChannel.setMethodCallHandler(null)
-  }
-
   init {
     methodChannel.setMethodCallHandler(this)
     container = FrameLayout(context)
     loadAdWithCallback(params)
+  }
+
+  private fun destroy() {
+    countDownTimer?.cancel()
+    TTMediationAdSdk.unregisterConfigCallback(mSettingConfigCallback)
+    container.removeAllViews()
+    mTTSplashAd?.destroy()
+    methodChannel.setMethodCallHandler(null)
+  }
+
+  override fun onFlutterViewDetached() {
+    destroy()
   }
 
   private fun loadAdByParam(params: Map<String, Any?>) {
@@ -71,7 +63,7 @@ class FlutterSplashView(
       val h: Int = imgArgs["height"] ?: 1920
       val outInfo: Map<String, String> = params["outInfo"]?.asMap() ?: mapOf()
       mTTSplashAd = TTSplashAd(context, slotId)
-      mTTSplashAd!!.setTTAdSplashListener(object : TTSplashAdListener {
+      mTTSplashAd?.setTTAdSplashListener(object : TTSplashAdListener {
         override fun onAdClicked() {
           postMessage("onClick")
         }
@@ -106,21 +98,19 @@ class FlutterSplashView(
         ttNetworkRequestInfo = PangleNetworkRequestInfo(outAppId, outSlotId)
       }
       //step4:请求广告，调用开屏广告异步请求接口，对请求回调的广告作渲染处理
-      mTTSplashAd!!.loadAd(adSlot, ttNetworkRequestInfo, object : TTSplashAdLoadCallback {
+      mTTSplashAd?.loadAd(adSlot, ttNetworkRequestInfo, object : TTSplashAdLoadCallback {
         override fun onSplashAdLoadFail(adError: AdError) {
           postMessage(
             "onError",
             mapOf(
-              "message" to adError.message + " adMessgaeDetail=" + mTTSplashAd!!.adLoadInfoList,
+              "message" to adError.message + " adMessgaeDetail=" + mTTSplashAd?.adLoadInfoList,
               "code" to adError.code
             )
           )
         }
 
         override fun onSplashAdLoadSuccess() {
-          if (mTTSplashAd != null) {
-            mTTSplashAd!!.showAd(container)
-          }
+          mTTSplashAd?.showAd(container)
         }
 
         override fun onAdLoadTimeout() {
@@ -135,7 +125,7 @@ class FlutterSplashView(
         override fun onTick(millisUntilFinished: Long) {
         }
       }
-      countDownTimer!!.start()
+      countDownTimer?.start()
     }
   }
 
@@ -176,9 +166,7 @@ class FlutterSplashView(
     method: String,
     arguments: Map<String, Any?> = mapOf()
   ) {
-    if(countDownTimer != null){
-      countDownTimer!!.cancel()
-    }
+    countDownTimer?.cancel()
     methodChannel.invokeMethod(method, arguments)
   }
 }


### PR DESCRIPTION
firebase: https://console.firebase.google.com/project/facemagic-6b63d/crashlytics/app/android:com.xgd.quyan/issues/30afacaaa1aab5302b43b4c8e66e8ba0?time=last-seven-days&sessionEventKey=616CDB5E011D00014FD9A6F52B4B3677_1598672862823408338
问题: splashView使用lateinit定义计时变量，destory时出现空指针异常